### PR TITLE
Handle "quit" command correctly during search

### DIFF
--- a/engine/src/timer.rs
+++ b/engine/src/timer.rs
@@ -17,13 +17,13 @@ impl Timer {
                 .recv()
                 .expect("Error receiving TimerCommand");
             match message {
-                TimerCommand::Start(dur) => {
-                    if timer_command_receiver.recv_timeout(dur).is_err() {
-                        search_command_sender
-                            .send(SearchCommand::Stop)
-                            .expect("Error sending SearchCommand");
-                    }
-                }
+                TimerCommand::Start(dur) => match timer_command_receiver.recv_timeout(dur) {
+                    Ok(TimerCommand::Start(_) | TimerCommand::Stop) => {}
+                    Ok(TimerCommand::Terminate) => break,
+                    Err(_) => search_command_sender
+                        .send(SearchCommand::Stop)
+                        .expect("Error sending SearchCommand"),
+                },
                 TimerCommand::Stop => {}
                 TimerCommand::Terminate => break,
             }

--- a/fatalii/Cargo.toml
+++ b/fatalii/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fatalii"
-version = "0.2.0"
+version = "0.2.0-alpha"
 edition = "2018"
 
 [dependencies]

--- a/fatalii/tests/cli.rs
+++ b/fatalii/tests/cli.rs
@@ -4,6 +4,12 @@ use std::{thread, time::Duration};
 
 #[test]
 fn test_cli() -> Result<()> {
+    uci_commands()?;
+    quit_while_timer_running()?;
+    Ok(())
+}
+
+fn uci_commands() -> Result<()> {
     let mut p = spawn("cargo run", Some(60000))?;
 
     p.send_line("uci")?;
@@ -31,6 +37,22 @@ fn test_cli() -> Result<()> {
     assert_matches!(p.process.status(), Some(WaitStatus::StillAlive));
     p.send_line("quit")?;
     thread::sleep(Duration::from_millis(100));
+    assert_matches!(p.process.status(), Some(WaitStatus::Exited(_, 0)));
+
+    Ok(())
+}
+
+fn quit_while_timer_running() -> Result<()> {
+    let mut p = spawn("cargo run", Some(60000))?;
+
+    p.send_line("uci")?;
+    p.send_line("isready")?;
+    p.send_line("ucinewgame")?;
+    p.send_line("position startpos")?;
+    p.send_line("go wtime 121000 btime 121000")?;
+    thread::sleep(Duration::from_millis(100));
+    p.send_line("quit")?;
+    thread::sleep(Duration::from_millis(400));
     assert_matches!(p.process.status(), Some(WaitStatus::Exited(_, 0)));
 
     Ok(())


### PR DESCRIPTION
- Previously, the timer thread could end up in an endless loop when a
  "quit" command was received after a "go" command with one of the
  options "wtime", "btime" or "movetime"