### PR TITLE
Improve root move ordering

### DIFF
--- a/movegen/src/transposition_table.rs
+++ b/movegen/src/transposition_table.rs
@@ -8,7 +8,7 @@ pub trait TtEntry {
     fn prio(&self, other: &Self, age: u8) -> cmp::Ordering;
 }
 
-const ENTRIES_PER_BUCKET: usize = 4;
+pub const ENTRIES_PER_BUCKET: usize = 4;
 const MAX_MATCHING_KEYS_PER_BUCKET: usize = 4;
 
 type Bucket<K, V> = [Option<(K, V)>; ENTRIES_PER_BUCKET];
@@ -127,6 +127,24 @@ where
             }
         }
         most_relevant
+    }
+
+    pub fn get_all(&self, k: &K) -> [Option<V>; ENTRIES_PER_BUCKET] {
+        let index = self.key_to_index(k);
+        let mut entries = [None; ENTRIES_PER_BUCKET];
+        let mut entry_idx = 0;
+        for entry in &self.buckets[index] {
+            match entry {
+                Some(ref e) if e.0 == *k => {
+                    entries[entry_idx] = Some(e.1);
+                    entry_idx += 1;
+                }
+                _ => {}
+            }
+        }
+        entries[0..entry_idx]
+            .sort_by_key(|e| cmp::Reverse(e.expect("Expected Some(_) entry, got None").depth()));
+        entries
     }
 
     // Inserts a value into the table

--- a/search/src/lib.rs
+++ b/search/src/lib.rs
@@ -7,6 +7,7 @@ pub mod searcher;
 
 mod alpha_beta_entry;
 mod history_table;
+mod move_candidates;
 mod move_selector;
 mod negamax_entry;
 mod node_counter;

--- a/search/src/move_candidates.rs
+++ b/search/src/move_candidates.rs
@@ -1,0 +1,19 @@
+use movegen::r#move::{Move, MoveList};
+
+#[derive(Debug, Default)]
+pub struct MoveCandidates {
+    pub move_list: MoveList,
+    pub current_idx: usize,
+}
+
+impl MoveCandidates {
+    pub fn move_to_front(&mut self, best_move: Move) {
+        let idx = self
+            .move_list
+            .iter()
+            .position(|&x| x == best_move)
+            .expect("Expected to find move {x} in candidates: {candidates:?}");
+        let slice = &mut self.move_list[0..=idx];
+        slice.rotate_right(1);
+    }
+}

--- a/search/src/move_selector.rs
+++ b/search/src/move_selector.rs
@@ -36,6 +36,10 @@ impl MoveSelector {
         depth: usize,
         move_list: &mut MoveList,
     ) -> Option<Move> {
+        if search_data.search_depth() > 1 && depth == search_data.search_depth() {
+            return Self::select_root_move(search_data);
+        }
+
         if self.stage == Stage::PrincipalVariation {
             if let Some(m) = Self::select_pv_move(search_data, depth, move_list) {
                 return Some(m);
@@ -360,6 +364,22 @@ impl MoveSelector {
             debug_assert_eq!(m, move_list[idx]);
             let next_move = move_list.swap_remove(idx);
             return Some(next_move);
+        }
+
+        None
+    }
+
+    fn select_root_move(search_data: &mut SearchData) -> Option<Move> {
+        if search_data.root_moves().current_idx == 0 {
+            search_data.decrease_pv_depth();
+        }
+        let candidates = search_data.root_moves_mut();
+        let moves = &candidates.move_list;
+        let idx = &mut candidates.current_idx;
+        if idx < &mut moves.len() {
+            let m = moves[*idx];
+            *idx += 1;
+            return Some(m);
         }
 
         None

--- a/search/src/search_data.rs
+++ b/search/src/search_data.rs
@@ -1,6 +1,7 @@
 use std::time::{Duration, Instant};
 
 use crate::history_table::HistoryTable;
+use crate::move_candidates::MoveCandidates;
 use crate::node_counter::NodeCounter;
 use crate::pv_table::PvTable;
 use crate::search::{SearchCommand, SearchInfo};
@@ -28,6 +29,7 @@ pub struct SearchData<'a> {
     node_counter: NodeCounter,
     killers: Vec<Killers>,
     history_table: HistoryTable,
+    move_candidates: MoveCandidates,
 }
 
 impl<'a> SearchData<'a> {
@@ -54,6 +56,7 @@ impl<'a> SearchData<'a> {
             node_counter: NodeCounter::new(),
             killers: Vec::new(),
             history_table: HistoryTable::new(),
+            move_candidates: MoveCandidates::default(),
         }
     }
 
@@ -159,6 +162,7 @@ impl<'a> SearchData<'a> {
         self.pv_depth = self.search_depth;
         self.search_depth += 1;
         self.killers.push([None; NUM_KILLERS]);
+        self.root_moves_mut().current_idx = 0;
     }
 
     pub fn decrease_pv_depth(&mut self) {
@@ -181,5 +185,20 @@ impl<'a> SearchData<'a> {
 
     pub fn increment_eval_calls(&mut self) {
         self.node_counter.increment_eval_calls(self.search_depth());
+    }
+
+    pub fn set_root_moves(&mut self, root_moves: MoveList) {
+        self.move_candidates = MoveCandidates {
+            move_list: root_moves,
+            ..Default::default()
+        };
+    }
+
+    pub fn root_moves(&self) -> &MoveCandidates {
+        &self.move_candidates
+    }
+
+    pub fn root_moves_mut(&mut self) -> &mut MoveCandidates {
+        &mut self.move_candidates
     }
 }


### PR DESCRIPTION
- Store ordered move list at the root
- Whenever a new best move is found, move it to the front of the list