### PR TITLE
Improve search

### DIFF
--- a/search/src/history_table.rs
+++ b/search/src/history_table.rs
@@ -1,8 +1,16 @@
-use movegen::{piece::Piece, square::Square};
+use movegen::{
+    piece::Piece,
+    position::Position,
+    r#move::{Move, MoveList},
+    square::Square,
+};
+
+const MAX_BONUS: i32 = (i16::MAX / 2) as i32;
+const HISTORY_DIVISOR: i32 = 16384;
 
 #[derive(Debug, Clone)]
 pub struct HistoryTable {
-    table: [u32; Piece::NUM_PIECES * Square::NUM_SQUARES],
+    table: [i16; Piece::NUM_PIECES * Square::NUM_SQUARES],
 }
 
 impl HistoryTable {
@@ -12,11 +20,33 @@ impl HistoryTable {
         }
     }
 
-    pub fn prioritize(&mut self, p: Piece, to: Square, depth: usize) {
-        self.table[Self::idx(p, to)] += (depth * depth) as u32;
+    pub fn update(&mut self, m: Move, depth: usize, moves_tried: &MoveList, pos: &Position) {
+        let bonus = Self::bonus(depth);
+        // Add a bonus to the fail-high move
+        let piece = pos
+            .piece_at(m.origin())
+            .expect("Expected a piece at move origin");
+        self.update_history(piece, m.target(), bonus);
+        // Subtract a penalty to all other tried moves
+        for mt in moves_tried.iter() {
+            let piece = pos
+                .piece_at(mt.origin())
+                .expect("Expected a piece at move origin");
+            self.update_history(piece, mt.target(), -bonus);
+        }
     }
 
-    pub fn priority(&self, p: Piece, to: Square) -> u32 {
+    fn bonus(depth: usize) -> i32 {
+        (16 * (depth * depth) as i32 + 128 * (depth as i32 - 1).max(0)).min(MAX_BONUS)
+    }
+
+    fn update_history(&mut self, p: Piece, s: Square, delta: i32) {
+        let idx = Self::idx(p, s);
+        let current = &mut self.table[idx];
+        *current += (delta - *current as i32 * delta.abs() / HISTORY_DIVISOR) as i16;
+    }
+
+    pub fn value(&self, p: Piece, to: Square) -> i16 {
         self.table[Self::idx(p, to)]
     }
 

--- a/search/src/move_selector.rs
+++ b/search/src/move_selector.rs
@@ -441,7 +441,7 @@ impl MoveSelector {
                     .current_pos()
                     .piece_at(x.r#move.origin())
                     .expect("Expected a piece at move origin");
-                history_table.priority(p, x.r#move.target())
+                history_table.value(p, x.r#move.target())
             })
         {
             debug_assert_eq!(m.r#move, self.moves[idx].r#move);


### PR DESCRIPTION
```
Score of Fatalii Movegen after Prune vs Fatalii TT Improvements: 3474 - 3284 - 3242  [0.509] 10000
...      Fatalii Movegen after Prune playing White: 1876 - 1515 - 1609  [0.536] 5000
...      Fatalii Movegen after Prune playing Black: 1598 - 1769 - 1633  [0.483] 5000
...      White vs Black: 3645 - 3113 - 3242  [0.527] 10000
Elo difference: 6.6 +/- 5.6, LOS: 99.0 %, DrawRatio: 32.4 %
SPRT: llr 1.96 (66.7%), lbound -2.94, ubound 2.94
```

```
Score of Fatalii Improve History vs Fatalii Movegen after Prune: 3049 - 2988 - 2996  [0.503] 9033
...      Fatalii Improve History playing White: 1639 - 1409 - 1469  [0.525] 4517
...      Fatalii Improve History playing Black: 1410 - 1579 - 1527  [0.481] 4516
...      White vs Black: 3218 - 2819 - 2996  [0.522] 9033
Elo difference: 2.3 +/- 5.8, LOS: 78.4 %, DrawRatio: 33.2 %
SPRT: llr -2.97 (-100.9%), lbound -2.94, ubound 2.94 - H0 was accepted
```