### PR TITLE
Refactor transposition table and search data

### DIFF
--- a/movegen/src/move.rs
+++ b/movegen/src/move.rs
@@ -66,7 +66,7 @@ impl MoveType {
 // Bits 0-5: origin square
 // Bits 6-11: target square
 // Bits 12-15: move type
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct Move(u16);
 
 impl Move {

--- a/movegen/src/transposition_table.rs
+++ b/movegen/src/transposition_table.rs
@@ -1,6 +1,8 @@
 use std::{cmp, mem};
 
-pub trait TtEntry {
+pub trait TtEntry: Default {
+    fn is_valid(&self) -> bool;
+
     fn depth(&self) -> usize;
 
     fn age(&self) -> u8;
@@ -10,7 +12,7 @@ pub trait TtEntry {
 
 pub const ENTRIES_PER_BUCKET: usize = 4;
 
-type Bucket<K, V> = [Option<(K, V)>; ENTRIES_PER_BUCKET];
+type Bucket<K, V> = [(K, V); ENTRIES_PER_BUCKET];
 
 #[derive(Debug)]
 pub struct TranspositionTable<K, V> {
@@ -21,22 +23,25 @@ pub struct TranspositionTable<K, V> {
 
 impl<K, V> TranspositionTable<K, V>
 where
-    K: Copy + Eq,
+    K: Copy + Default + Eq,
     V: Copy + TtEntry,
     u64: From<K>,
 {
     pub fn new(bytes: usize) -> TranspositionTable<K, V> {
         debug_assert!(bytes <= u64::MAX as usize);
-        let bucket_size = mem::size_of::<Option<(K, V)>>() * ENTRIES_PER_BUCKET;
         // Reserve memory for at least 2 buckets, so that at least one index bit
         // is used (even if bytes is 0)
-        let max_num_buckets = cmp::max(2, bytes / bucket_size);
+        let max_num_buckets = cmp::max(2, bytes / Self::bucket_size());
         // The actual number of buckets must be a power of 2.
         let index_bits = 64 - max_num_buckets.leading_zeros() - 1;
         debug_assert!(index_bits <= 64);
         TranspositionTable {
             index_bits: index_bits as usize,
-            buckets: vec![[None; ENTRIES_PER_BUCKET]; 2_usize.pow(index_bits)].into_boxed_slice(),
+            buckets: vec![
+                [(Default::default(), Default::default()); ENTRIES_PER_BUCKET];
+                2_usize.pow(index_bits)
+            ]
+            .into_boxed_slice(),
             len: 0,
         }
     }
@@ -46,7 +51,7 @@ where
             self.len,
             self.buckets
                 .iter()
-                .map(|b| b.iter().filter(|x| x.is_some()).count())
+                .map(|b| b.iter().filter(|(_, v)| v.is_valid()).count())
                 .sum()
         );
         self.len
@@ -55,7 +60,9 @@ where
     pub fn is_empty(&self) -> bool {
         debug_assert_eq!(
             self.len == 0,
-            self.buckets.iter().all(|b| b.iter().all(|x| x.is_none()))
+            self.buckets
+                .iter()
+                .all(|b| b.iter().all(|(_, v)| !v.is_valid()))
         );
         self.len == 0
     }
@@ -65,7 +72,8 @@ where
     }
 
     pub fn clear(&mut self) {
-        self.buckets.fill([None; ENTRIES_PER_BUCKET]);
+        self.buckets
+            .fill([(Default::default(), Default::default()); ENTRIES_PER_BUCKET]);
         self.len = 0;
     }
 
@@ -77,10 +85,9 @@ where
     pub fn contains_key(&self, k: &K) -> bool {
         let bucket_idx = self.key_to_index(k);
         for entry in self.buckets[bucket_idx] {
-            match entry {
-                Some(e) if e.0 == *k => return true,
-                _ => {}
-            };
+            if entry.1.is_valid() && entry.0 == *k {
+                return true;
+            }
         }
         false
     }
@@ -89,9 +96,8 @@ where
     pub fn get(&self, k: &K) -> Option<&V> {
         let bucket_idx = self.key_to_index(k);
         for entry in &self.buckets[bucket_idx] {
-            match entry {
-                Some(ref e) if e.0 == *k => return Some(&e.1),
-                _ => {}
+            if entry.1.is_valid() && entry.0 == *k {
+                return Some(&entry.1);
             }
         }
         None
@@ -114,48 +120,48 @@ where
         let mut replaced = None;
         let bucket = &mut self.buckets[bucket_idx];
         for (i, entry) in bucket.iter_mut().enumerate() {
-            match entry {
-                Some(ent) if ent.0 == k => {
-                    // Existing entry has the same hash value as the new one
-                    if let cmp::Ordering::Greater = value.prio(&ent.1, value.age()) {
-                        // New prio > old prio => keep existing entry
-                        return None;
-                    }
-                    replaced_idx = Some(i);
-                    replaced = Some(*ent);
-                    break;
+            if !entry.1.is_valid() {
+                // Entry is invalid => replace it
+                replaced_idx = Some(i);
+                replaced = None;
+                break;
+            }
+            if entry.0 == k {
+                // Existing entry has the same hash value as the new one
+                if let cmp::Ordering::Greater = value.prio(&entry.1, value.age()) {
+                    // New prio > old prio => keep existing entry
+                    return None;
                 }
-                Some(ent) => {
-                    // Different hash values
-                    match replaced {
-                        None => {
-                            replaced_idx = Some(i);
-                            replaced = Some(*ent);
-                        }
-                        Some(rep) => {
-                            if let cmp::Ordering::Greater = ent.1.prio(&rep.1, value.age()) {
-                                replaced_idx = Some(i);
-                                replaced = Some(*ent);
-                            }
-                        }
-                    }
-                }
+                replaced_idx = Some(i);
+                replaced = Some(*entry);
+                break;
+            }
+            // Existing and new entries have different hash values
+            match replaced {
                 None => {
-                    // Entry is None => replace it
                     replaced_idx = Some(i);
-                    replaced = None;
-                    break;
+                    replaced = Some(*entry);
+                }
+                Some(rep) => {
+                    if let cmp::Ordering::Greater = entry.1.prio(&rep.1, value.age()) {
+                        replaced_idx = Some(i);
+                        replaced = Some(*entry);
+                    }
                 }
             }
         }
         match replaced_idx {
             Some(rep_idx) => {
-                self.buckets[bucket_idx][rep_idx] = Some((k, value));
+                self.buckets[bucket_idx][rep_idx] = (k, value);
                 self.len += replaced.is_none() as usize;
                 replaced
             }
             None => None,
         }
+    }
+
+    pub fn bucket_size() -> usize {
+        mem::size_of::<(K, V)>() * ENTRIES_PER_BUCKET
     }
 
     pub fn reserved_memory(&self) -> usize {
@@ -176,56 +182,75 @@ mod tests {
     use crate::square::Square;
     use crate::zobrist::Zobrist;
 
-    impl TtEntry for u64 {
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+    struct U64Entry {
+        is_valid: bool,
+        value: u64,
+    }
+
+    impl TtEntry for U64Entry {
+        fn is_valid(&self) -> bool {
+            self.is_valid
+        }
+
         fn depth(&self) -> usize {
-            *self as usize
+            self.value as usize
         }
 
         fn age(&self) -> u8 {
-            (self % 256) as u8
+            (self.value % 128) as u8
         }
 
         fn prio(&self, other: &Self, age: u8) -> cmp::Ordering {
-            let halfmoves_since_self = ((age as u16 + 256 - self.age() as u16) % 256) as u8;
-            let halfmoves_since_other = ((age as u16 + 256 - other.age() as u16) % 256) as u8;
+            let halfmoves_since_self = ((age as u16 + 128 - self.age() as u16) % 128) as u8;
+            let halfmoves_since_other = ((age as u16 + 128 - other.age() as u16) % 128) as u8;
             match halfmoves_since_self.cmp(&halfmoves_since_other) {
                 cmp::Ordering::Less => cmp::Ordering::Less,
-                cmp::Ordering::Equal => self.cmp(other).reverse(),
+                cmp::Ordering::Equal => self.value.cmp(&other.value).reverse(),
                 cmp::Ordering::Greater => cmp::Ordering::Greater,
+            }
+        }
+    }
+
+    impl From<u64> for U64Entry {
+        fn from(value: u64) -> Self {
+            Self {
+                is_valid: true,
+                value,
             }
         }
     }
 
     #[test]
     fn new() {
-        let bucket_size = mem::size_of::<Option<(u64, u64)>>() * ENTRIES_PER_BUCKET;
+        let bucket_size = TranspositionTable::<u64, U64Entry>::bucket_size();
 
         // Always reserve memory for at least two buckets
-        let tt = TranspositionTable::<u64, u64>::new(0);
+        let tt = TranspositionTable::<u64, U64Entry>::new(0);
         assert_eq!(2 * bucket_size, tt.reserved_memory());
-        let tt = TranspositionTable::<u64, u64>::new(bucket_size);
+        let tt = TranspositionTable::<u64, U64Entry>::new(bucket_size);
         assert_eq!(2 * bucket_size, tt.reserved_memory());
-        let tt = TranspositionTable::<u64, u64>::new(2 * bucket_size);
+        let tt = TranspositionTable::<u64, U64Entry>::new(2 * bucket_size);
         assert_eq!(2 * bucket_size, tt.reserved_memory());
-        let tt = TranspositionTable::<u64, u64>::new(4 * bucket_size - 1);
+        let tt = TranspositionTable::<u64, U64Entry>::new(4 * bucket_size - 1);
         assert_eq!(2 * bucket_size, tt.reserved_memory());
-        let tt = TranspositionTable::<u64, u64>::new(4 * bucket_size);
+        let tt = TranspositionTable::<u64, U64Entry>::new(4 * bucket_size);
         assert_eq!(4 * bucket_size, tt.reserved_memory());
-        let tt = TranspositionTable::<u64, u64>::new(4 * bucket_size + 1);
+        let tt = TranspositionTable::<u64, U64Entry>::new(4 * bucket_size + 1);
         assert_eq!(4 * bucket_size, tt.reserved_memory());
 
         // Don't reserve more memory than wanted (if it is enough for 2 entries)
-        let tt = TranspositionTable::<u64, u64>::new(1000);
+        let tt = TranspositionTable::<u64, U64Entry>::new(1000);
         assert!(tt.reserved_memory() <= 1000);
-        let tt = TranspositionTable::<u64, u64>::new(2000);
+        let tt = TranspositionTable::<u64, U64Entry>::new(2000);
         assert!(tt.reserved_memory() <= 2000);
     }
 
     #[test]
     fn insert_and_replace_and_clear() {
         let capacity = 8 * ENTRIES_PER_BUCKET;
-        let entry_size = mem::size_of::<Option<(u64, u64)>>();
-        let mut tt = TranspositionTable::<u64, u64>::new(capacity * entry_size);
+        let entry_size = mem::size_of::<(u64, U64Entry)>();
+        let mut tt = TranspositionTable::<u64, U64Entry>::new(capacity * entry_size);
 
         assert!(!tt.contains_key(&0));
         assert_eq!(None, tt.get(&0));
@@ -237,15 +262,17 @@ mod tests {
         assert_eq!(0, tt.load_factor_permille());
 
         for i in 0..ENTRIES_PER_BUCKET {
-            let num = i as u64;
-            let replaced = tt.insert(num, num);
+            let key = i as u64;
+            let value = U64Entry::from(key);
+            let replaced = tt.insert(key, value);
             assert_eq!(None, replaced);
         }
 
         for i in 0..ENTRIES_PER_BUCKET {
-            let num = i as u64;
-            assert!(tt.contains_key(&num));
-            assert_eq!(Some(&num), tt.get(&num));
+            let key = i as u64;
+            let value = U64Entry::from(key);
+            assert!(tt.contains_key(&key));
+            assert_eq!(Some(&value), tt.get(&key));
         }
 
         assert_eq!(ENTRIES_PER_BUCKET, tt.len());
@@ -260,24 +287,24 @@ mod tests {
         assert!(!tt.contains_key(&inserted));
         assert_eq!(None, tt.get(&inserted));
 
-        let replaced = tt.insert(inserted, inserted);
-        assert_eq!(Some((0, 0)), replaced);
+        let replaced = tt.insert(inserted, inserted.into());
+        assert_eq!(Some((0, 0.into())), replaced);
         assert!(!tt.contains_key(&0));
         assert_eq!(None, tt.get(&0));
         assert!(tt.contains_key(&1));
-        assert_eq!(Some(&1), tt.get(&1));
+        assert_eq!(Some(&1.into()), tt.get(&1));
         assert!(tt.contains_key(&inserted));
-        assert_eq!(Some(&inserted), tt.get(&inserted));
+        assert_eq!(Some(&inserted.into()), tt.get(&inserted));
 
         let another_inserted = inserted + 1;
-        let replaced = tt.insert(another_inserted, another_inserted);
-        assert_eq!(Some((1, 1)), replaced);
+        let replaced = tt.insert(another_inserted, another_inserted.into());
+        assert_eq!(Some((1, 1.into())), replaced);
         assert!(!tt.contains_key(&1));
         assert_eq!(None, tt.get(&1));
         assert!(tt.contains_key(&another_inserted));
-        assert_eq!(Some(&another_inserted), tt.get(&another_inserted));
+        assert_eq!(Some(&another_inserted.into()), tt.get(&another_inserted));
 
-        let _ = tt.insert(0xff00_0000_0000_0000, 2);
+        let _ = tt.insert(0xff00_0000_0000_0000, 2.into());
         assert_eq!(ENTRIES_PER_BUCKET + 1, tt.len());
         assert!(!tt.is_empty());
         assert_eq!(capacity, tt.capacity());
@@ -303,16 +330,16 @@ mod tests {
     fn position_with_zobrist() {
         let capacity = 16 * ENTRIES_PER_BUCKET;
         let entry_size = mem::size_of::<Option<(Zobrist, u64)>>();
-        let mut tt = TranspositionTable::<Zobrist, u64>::new(capacity * entry_size);
+        let mut tt = TranspositionTable::<Zobrist, U64Entry>::new(capacity * entry_size);
 
         let mut pos_history = PositionHistory::new(Position::initial());
         let hash = pos_history.current_pos_hash();
         assert!(!tt.contains_key(&hash));
         assert_eq!(None, tt.get(&hash));
-        let old_entry = tt.insert(hash, 0);
+        let old_entry = tt.insert(hash, 0.into());
         assert_eq!(None, old_entry);
         assert!(tt.contains_key(&hash));
-        assert_eq!(Some(&0), tt.get(&hash));
+        assert_eq!(Some(&0.into()), tt.get(&hash));
 
         pos_history.do_move(Move::new(
             Square::E2,
@@ -322,40 +349,40 @@ mod tests {
         let hash = pos_history.current_pos_hash();
         assert!(!tt.contains_key(&hash));
         assert_eq!(None, tt.get(&hash));
-        let old_entry = tt.insert(hash, 1);
+        let old_entry = tt.insert(hash, 1.into());
         assert_eq!(None, old_entry);
         assert!(tt.contains_key(&hash));
-        assert_eq!(Some(&1), tt.get(&hash));
+        assert_eq!(Some(&1.into()), tt.get(&hash));
 
         pos_history.undo_last_move();
         let hash = pos_history.current_pos_hash();
         assert!(tt.contains_key(&hash));
-        assert_eq!(Some(&0), tt.get(&hash));
-        let old_entry = tt.insert(hash, 0);
-        assert_eq!(Some((hash, 0)), old_entry);
+        assert_eq!(Some(&0.into()), tt.get(&hash));
+        let old_entry = tt.insert(hash, 0.into());
+        assert_eq!(Some((hash, 0.into())), old_entry);
         assert!(tt.contains_key(&hash));
-        assert_eq!(Some(&0), tt.get(&hash));
+        assert_eq!(Some(&0.into()), tt.get(&hash));
     }
 
     #[test]
     fn replace_correct_entry() {
         let capacity = 8 * ENTRIES_PER_BUCKET;
-        let entry_size = mem::size_of::<Option<(u64, u64)>>();
-        let mut tt = TranspositionTable::<u64, u64>::new(capacity * entry_size);
+        let entry_size = mem::size_of::<Option<(u64, U64Entry)>>();
+        let mut tt = TranspositionTable::<u64, U64Entry>::new(capacity * entry_size);
         assert!(tt.is_empty());
 
-        let replaced = tt.insert(0, 0);
+        let replaced = tt.insert(0, 0.into());
         assert_eq!(None, replaced);
-        let replaced = tt.insert(0, 1);
-        assert_eq!(Some((0, 0)), replaced);
+        let replaced = tt.insert(0, 1.into());
+        assert_eq!(Some((0, 0.into())), replaced);
         assert_eq!(1, tt.len());
 
-        let replaced = tt.insert(1, 1);
+        let replaced = tt.insert(1, 1.into());
         assert_eq!(None, replaced);
         assert_eq!(2, tt.len());
 
-        let replaced = tt.insert(0, 0);
-        assert_eq!(Some((0, 1)), replaced);
+        let replaced = tt.insert(0, 0.into());
+        assert_eq!(Some((0, 1.into())), replaced);
         assert_eq!(2, tt.len());
     }
 }

--- a/movegen/src/zobrist.rs
+++ b/movegen/src/zobrist.rs
@@ -19,7 +19,7 @@ const IDX_BLACK_KINGSIDE: usize = 771;
 const IDX_BLACK_QUEENSIDE: usize = 772;
 const IDX_FIRST_EN_PASSANT_FILE: usize = 773;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub struct Zobrist(u64);
 
 impl Zobrist {

--- a/perft/src/lib.rs
+++ b/perft/src/lib.rs
@@ -8,13 +8,18 @@ use movegen::zobrist::Zobrist;
 
 const AGE: u8 = 0;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 struct TableEntry {
+    is_valid: bool,
     depth: usize,
     num_nodes: usize,
 }
 
 impl TtEntry for TableEntry {
+    fn is_valid(&self) -> bool {
+        self.is_valid
+    }
+
     fn depth(&self) -> usize {
         self.depth
     }
@@ -81,8 +86,14 @@ impl PerformanceTester {
                                         self.count_nodes_recursive(move_list_stack, depth - 1);
                                     self.pos_history.undo_last_move();
                                 }
-                                self.transpos_table
-                                    .insert(hash, TableEntry { depth, num_nodes });
+                                self.transpos_table.insert(
+                                    hash,
+                                    TableEntry {
+                                        is_valid: true,
+                                        depth,
+                                        num_nodes,
+                                    },
+                                );
                             }
                         }
                         move_list_stack.push(move_list);

--- a/search/src/search.rs
+++ b/search/src/search.rs
@@ -7,7 +7,7 @@ use movegen::r#move::{Move, MoveList};
 use std::fmt;
 use std::ops::Neg;
 
-pub const MAX_SEARCH_DEPTH: usize = u8::MAX as usize;
+pub const MAX_SEARCH_DEPTH: usize = 127;
 pub const REPETITIONS_TO_DRAW: usize = 3;
 pub const PLIES_WITHOUT_PAWN_MOVE_OR_CAPTURE_TO_DRAW: usize = 100;
 


### PR DESCRIPTION
- Store static evaluation in transposition table and refactor entries to still fit into 16 bytes
- Reduce max search depth and max age from 255 to 127 to save a bit
- Clean up code