### PR TITLE
Update conditions for late move reductions

### DIFF
--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -6,7 +6,7 @@ use movegen::position::Position;
 use movegen::position_history::PositionHistory;
 use movegen::side::Side;
 use search::search::{Search, SearchInfo};
-use search::search_params::SearchParamsEachAlgo;
+use search::search_params::SearchParamsOptions;
 use search::searcher::Searcher;
 use search::SearchOptions;
 use std::sync::{Arc, Mutex};
@@ -87,7 +87,7 @@ impl Engine {
         };
     }
 
-    pub fn set_search_params(&mut self, search_params: SearchParamsEachAlgo) {
+    pub fn set_search_params(&mut self, search_params: SearchParamsOptions) {
         self.searcher.set_search_params(search_params);
     }
 

--- a/search/src/alpha_beta.rs
+++ b/search/src/alpha_beta.rs
@@ -385,7 +385,6 @@ impl AlphaBeta {
                 true
             });
 
-            let is_pv_node = alpha != beta - 1;
             let is_quiet = !m.is_capture() && !m.is_promotion();
 
             skip_quiets |= self.prune_late_move(search_data, move_count);
@@ -418,16 +417,10 @@ impl AlphaBeta {
             search_data.set_current_extension(extension);
 
             // Late move reductions
-            let reduction = if !is_pv_node
-                && depth >= MIN_LATE_MOVE_REDUCTION_DEPTH
-                && extension == 0
-                && is_quiet
-            {
-                Self::late_move_depth_reduction(depth, quiets_tried.len())
-            } else {
-                0
-            };
-            search_data.set_current_reduction(reduction);
+            if depth >= MIN_LATE_MOVE_REDUCTION_DEPTH && is_quiet {
+                let reduction = Self::late_move_depth_reduction(depth, move_count);
+                search_data.set_current_reduction(reduction);
+            }
 
             let search_res =
                 match self.principal_variation_search(search_data, alpha, beta, pvs_full_window) {

--- a/search/src/alpha_beta.rs
+++ b/search/src/alpha_beta.rs
@@ -82,6 +82,20 @@ impl Search for AlphaBeta {
         if let Some(val) = params.late_move_pruning_max_depth {
             self.search_params.late_move_pruning_max_depth = val;
         }
+        if let Some(val) = params.late_move_reductions_centi_base {
+            self.search_params.late_move_reductions_centi_base = val;
+            self.lmr_table = LmrTable::new(
+                self.search_params.late_move_reductions_centi_base,
+                self.search_params.late_move_reductions_centi_divisor,
+            );
+        }
+        if let Some(val) = params.late_move_reductions_centi_divisor {
+            self.search_params.late_move_reductions_centi_divisor = val;
+            self.lmr_table = LmrTable::new(
+                self.search_params.late_move_reductions_centi_base,
+                self.search_params.late_move_reductions_centi_divisor,
+            );
+        }
         if let Some(val) = params.see_pruning_margin_quiet {
             self.search_params.see_pruning_margin_quiet = val;
         }
@@ -225,13 +239,18 @@ impl Search for AlphaBeta {
 
 impl AlphaBeta {
     pub fn new(evaluator: Box<dyn Eval + Send>, table_size: usize) -> Self {
+        let search_params = SearchParams::default();
+        let lmr_table = LmrTable::new(
+            search_params.late_move_reductions_centi_base,
+            search_params.late_move_reductions_centi_divisor,
+        );
         Self {
             evaluator,
             transpos_table: AlphaBetaTable::new(table_size),
             counter_table: CounterTable::new(),
             history_table: HistoryTable::new(),
-            lmr_table: LmrTable::new(),
-            search_params: SearchParams::default(),
+            lmr_table,
+            search_params,
         }
     }
 

--- a/search/src/aspiration_window.rs
+++ b/search/src/aspiration_window.rs
@@ -1,7 +1,5 @@
+use crate::search_params::SearchParams;
 use eval::{Score, NEG_INF, POS_INF};
-
-pub const INITIAL_WIDTH: i32 = 101;
-pub const GROW_RATE: i32 = 15;
 
 #[derive(Debug)]
 pub struct AspirationWindow {
@@ -19,7 +17,7 @@ impl AspirationWindow {
             score: 0,
             width_up: POS_INF as i32,
             width_down: POS_INF as i32,
-            grow_rate: GROW_RATE,
+            grow_rate: SearchParams::default().aspiration_window_grow_rate,
             alpha: NEG_INF,
             beta: POS_INF,
         }
@@ -77,17 +75,48 @@ mod tests {
     #[test]
     fn widen() {
         let score = 200;
-        let mut aw = AspirationWindow::new(score, INITIAL_WIDTH, GROW_RATE);
-        assert_eq!(score - INITIAL_WIDTH as Score, aw.alpha());
-        assert_eq!(score + INITIAL_WIDTH as Score, aw.beta());
+        let mut aw = AspirationWindow::new(
+            score,
+            SearchParams::default().aspiration_window_initial_width,
+            SearchParams::default().aspiration_window_grow_rate,
+        );
+        assert_eq!(
+            score - SearchParams::default().aspiration_window_initial_width as Score,
+            aw.alpha()
+        );
+        assert_eq!(
+            score + SearchParams::default().aspiration_window_initial_width as Score,
+            aw.beta()
+        );
 
         aw.widen_down();
-        assert_eq!(score - (INITIAL_WIDTH * GROW_RATE) as Score, aw.alpha());
-        assert_eq!(score + INITIAL_WIDTH as Score, aw.beta());
+        assert_eq!(
+            score
+                - (SearchParams::default().aspiration_window_initial_width
+                    * SearchParams::default().aspiration_window_grow_rate)
+                    as Score,
+            aw.alpha()
+        );
+        assert_eq!(
+            score + SearchParams::default().aspiration_window_initial_width as Score,
+            aw.beta()
+        );
 
         aw.widen_up();
-        assert_eq!(score - (INITIAL_WIDTH * GROW_RATE) as Score, aw.alpha());
-        assert_eq!(score + (INITIAL_WIDTH * GROW_RATE) as Score, aw.beta());
+        assert_eq!(
+            score
+                - (SearchParams::default().aspiration_window_initial_width
+                    * SearchParams::default().aspiration_window_grow_rate)
+                    as Score,
+            aw.alpha()
+        );
+        assert_eq!(
+            score
+                + (SearchParams::default().aspiration_window_initial_width
+                    * SearchParams::default().aspiration_window_grow_rate)
+                    as Score,
+            aw.beta()
+        );
 
         let mut prev_alpha = aw.alpha() + 1;
         while aw.alpha() != prev_alpha {
@@ -103,7 +132,11 @@ mod tests {
         assert_eq!(POS_INF, aw.beta());
 
         let neg_score = -1000;
-        let mut neg_aw = AspirationWindow::new(neg_score, INITIAL_WIDTH, GROW_RATE);
+        let mut neg_aw = AspirationWindow::new(
+            neg_score,
+            SearchParams::default().aspiration_window_initial_width,
+            SearchParams::default().aspiration_window_grow_rate,
+        );
         let mut prev_alpha = neg_aw.alpha() + 1;
         while neg_aw.alpha() != prev_alpha {
             prev_alpha = neg_aw.alpha();

--- a/search/src/lib.rs
+++ b/search/src/lib.rs
@@ -9,6 +9,7 @@ pub mod searcher;
 mod alpha_beta_entry;
 mod counter_table;
 mod history_table;
+mod lmr_table;
 mod move_candidates;
 mod move_selector;
 mod node_counter;

--- a/search/src/lmr_table.rs
+++ b/search/src/lmr_table.rs
@@ -1,0 +1,29 @@
+const LEN_DEPTH: usize = 64;
+const LEN_MOVE_COUNT: usize = 64;
+const LMR_CENTI_BASE: usize = 25;
+const LMR_CENTI_DIVISOR: usize = 500;
+
+#[derive(Debug, Clone)]
+pub struct LmrTable {
+    table: [[u8; 64]; 64],
+}
+
+impl LmrTable {
+    pub fn new() -> Self {
+        let mut table = [[0; LEN_MOVE_COUNT]; LEN_DEPTH];
+        let base = LMR_CENTI_BASE as f64 / 100.0;
+        let divisor = LMR_CENTI_DIVISOR as f64 / 100.0;
+        for (depth, table_row) in table.iter_mut().enumerate().skip(1) {
+            let log_depth = (depth as f64).log2();
+            for (move_count, reduction) in table_row.iter_mut().enumerate().skip(1) {
+                let log_move_count = (move_count as f64).log2();
+                *reduction = (base + log_depth * log_move_count / divisor) as u8;
+            }
+        }
+        Self { table }
+    }
+
+    pub fn late_move_depth_reduction(&self, depth: usize, move_count: usize) -> usize {
+        self.table[depth.min(LEN_DEPTH - 1)][move_count.min(LEN_MOVE_COUNT - 1)].into()
+    }
+}

--- a/search/src/lmr_table.rs
+++ b/search/src/lmr_table.rs
@@ -1,7 +1,5 @@
 const LEN_DEPTH: usize = 64;
 const LEN_MOVE_COUNT: usize = 64;
-const LMR_CENTI_BASE: usize = 25;
-const LMR_CENTI_DIVISOR: usize = 500;
 
 #[derive(Debug, Clone)]
 pub struct LmrTable {
@@ -9,10 +7,10 @@ pub struct LmrTable {
 }
 
 impl LmrTable {
-    pub fn new() -> Self {
+    pub fn new(centi_base: usize, centi_divisor: usize) -> Self {
         let mut table = [[0; LEN_MOVE_COUNT]; LEN_DEPTH];
-        let base = LMR_CENTI_BASE as f64 / 100.0;
-        let divisor = LMR_CENTI_DIVISOR as f64 / 100.0;
+        let base = centi_base as f64 / 100.0;
+        let divisor = centi_divisor as f64 / 100.0;
         for (depth, table_row) in table.iter_mut().enumerate().skip(1) {
             let log_depth = (depth as f64).log2();
             for (move_count, reduction) in table_row.iter_mut().enumerate().skip(1) {

--- a/search/src/search.rs
+++ b/search/src/search.rs
@@ -1,4 +1,4 @@
-use crate::search_params::SearchParamsEachAlgo;
+use crate::search_params::SearchParamsOptions;
 use crate::SearchOptions;
 use crossbeam_channel::{Receiver, Sender};
 use eval::Score;
@@ -130,7 +130,7 @@ impl fmt::Display for SearchResult {
 pub enum SearchCommand {
     SetHashSize(usize, Sender<()>),
     ClearHashTable(Sender<()>),
-    SetSearchParams(SearchParamsEachAlgo, Sender<()>),
+    SetSearchParams(SearchParamsOptions, Sender<()>),
     Search(Box<(PositionHistory, SearchOptions)>),
     Stop,
     Terminate,
@@ -158,7 +158,7 @@ pub trait Search {
 
     fn clear_hash_table(&mut self);
 
-    fn set_params(&mut self, params: SearchParamsEachAlgo);
+    fn set_params(&mut self, params: SearchParamsOptions);
 
     fn search(
         &mut self,

--- a/search/src/search_data.rs
+++ b/search/src/search_data.rs
@@ -167,7 +167,13 @@ impl<'a> SearchData<'a> {
     }
 
     pub fn net_search_depth(&self) -> usize {
-        debug_assert!(self.search_depth() + self.total_extensions() > self.total_reductions());
+        debug_assert!(
+            self.search_depth() + self.total_extensions() > self.total_reductions(),
+            "search_depth: {}\ntotal_extensions: {}\ntotal_reductions: {}",
+            self.search_depth(),
+            self.total_extensions(),
+            self.total_reductions(),
+        );
         self.search_depth() + self.total_extensions() - self.total_reductions()
     }
 

--- a/search/src/search_params.rs
+++ b/search/src/search_params.rs
@@ -1,9 +1,85 @@
 use eval::Score;
 
-pub trait SearchParams {}
+// Minimum depth for principal variation search. Disable null-window searches below this depth.
+pub const MIN_PVS_DEPTH: usize = 3;
+
+// Minimum depth for null move pruning.
+pub const MIN_NULL_MOVE_PRUNE_DEPTH: usize = 3;
+
+// Minimum depth for late move reductions.
+pub const MIN_LATE_MOVE_REDUCTION_DEPTH: usize = 3;
+
+// Enable futility pruning if the evaluation plus this value is less than alpha.
+const FUTILITY_MARGIN_BASE: Score = 12;
+const FUTILITY_MARGIN_PER_DEPTH: Score = 235;
+const FUTILITY_PRUNING_MAX_DEPTH: usize = 5;
+
+// Enable reverse futility pruning if the evaluation plus this value is greater than or equal to beta.
+const REVERSE_FUTILITY_MARGIN_BASE: Score = 115;
+const REVERSE_FUTILITY_MARGIN_PER_DEPTH: Score = 51;
+const REVERSE_FUTILITY_PRUNING_MAX_DEPTH: usize = 6;
+
+// Late move pruning
+const LATE_MOVE_PRUNING_BASE: usize = 4;
+const LATE_MOVE_PRUNING_FACTOR: usize = 1;
+const LATE_MOVE_PRUNING_MAX_DEPTH: usize = 5;
+
+// Prune a move if the static evaluation plus the move's potential improvement
+// plus this value is less than alpha.
+pub const DELTA_PRUNING_MARGIN_MOVE: Score = 200;
+
+// Prune all moves if the static evaluation plus this value is less than alpha.
+pub const DELTA_PRUNING_MARGIN_ALL_MOVES: Score = 1800;
+
+// Static exchange evaluation pruning
+const SEE_PRUNING_MARGIN_QUIET: Score = -100;
+const SEE_PRUNING_MARGIN_TACTICAL: Score = -50;
+const SEE_PRUNING_MAX_DEPTH: usize = 4;
+
+// Aspiration windows initial width and grow rate on fail-low/hign
+const ASPIRATION_WINDOW_INITIAL_WIDTH: i32 = 101;
+const ASPIRATION_WINDOW_GROW_RATE: i32 = 15;
+
+pub struct SearchParams {
+    pub futility_margin_base: Score,
+    pub futility_margin_per_depth: Score,
+    pub futility_pruning_max_depth: usize,
+    pub reverse_futility_margin_base: Score,
+    pub reverse_futility_margin_per_depth: Score,
+    pub reverse_futility_pruning_max_depth: usize,
+    pub late_move_pruning_base: usize,
+    pub late_move_pruning_factor: usize,
+    pub late_move_pruning_max_depth: usize,
+    pub see_pruning_margin_quiet: Score,
+    pub see_pruning_margin_tactical: Score,
+    pub see_pruning_max_depth: usize,
+    pub aspiration_window_initial_width: i32,
+    pub aspiration_window_grow_rate: i32,
+}
+
+impl Default for SearchParams {
+    fn default() -> Self {
+        Self {
+            futility_margin_base: FUTILITY_MARGIN_BASE,
+            futility_margin_per_depth: FUTILITY_MARGIN_PER_DEPTH,
+            futility_pruning_max_depth: FUTILITY_PRUNING_MAX_DEPTH,
+            reverse_futility_margin_base: REVERSE_FUTILITY_MARGIN_BASE,
+            reverse_futility_margin_per_depth: REVERSE_FUTILITY_MARGIN_PER_DEPTH,
+            reverse_futility_pruning_max_depth: REVERSE_FUTILITY_PRUNING_MAX_DEPTH,
+            late_move_pruning_base: LATE_MOVE_PRUNING_BASE,
+            late_move_pruning_factor: LATE_MOVE_PRUNING_FACTOR,
+            late_move_pruning_max_depth: LATE_MOVE_PRUNING_MAX_DEPTH,
+            see_pruning_margin_quiet: SEE_PRUNING_MARGIN_QUIET,
+            see_pruning_margin_tactical: SEE_PRUNING_MARGIN_TACTICAL,
+            see_pruning_max_depth: SEE_PRUNING_MAX_DEPTH,
+            aspiration_window_initial_width: ASPIRATION_WINDOW_INITIAL_WIDTH,
+            aspiration_window_grow_rate: ASPIRATION_WINDOW_GROW_RATE,
+        }
+    }
+}
 
 #[derive(Debug, Default)]
-pub struct AlphaBetaParams {
+pub struct SearchParamsOptions {
     pub futility_margin_base: Option<Score>,
     pub futility_margin_per_depth: Option<Score>,
     pub futility_pruning_max_depth: Option<usize>,
@@ -18,11 +94,4 @@ pub struct AlphaBetaParams {
     pub see_pruning_max_depth: Option<usize>,
     pub aspiration_window_initial_width: Option<i32>,
     pub aspiration_window_grow_rate: Option<i32>,
-}
-
-impl SearchParams for AlphaBetaParams {}
-
-#[derive(Debug)]
-pub enum SearchParamsEachAlgo {
-    AlphaBeta(AlphaBetaParams),
 }

--- a/search/src/search_params.rs
+++ b/search/src/search_params.rs
@@ -24,6 +24,10 @@ const LATE_MOVE_PRUNING_BASE: usize = 4;
 const LATE_MOVE_PRUNING_FACTOR: usize = 1;
 const LATE_MOVE_PRUNING_MAX_DEPTH: usize = 5;
 
+// Late move reductions
+const LATE_MOVE_REDUCTIONS_CENTI_BASE: usize = 25;
+const LATE_MOVE_REDUCTIONS_CENTI_DIVISOR: usize = 500;
+
 // Prune a move if the static evaluation plus the move's potential improvement
 // plus this value is less than alpha.
 pub const DELTA_PRUNING_MARGIN_MOVE: Score = 200;
@@ -50,6 +54,8 @@ pub struct SearchParams {
     pub late_move_pruning_base: usize,
     pub late_move_pruning_factor: usize,
     pub late_move_pruning_max_depth: usize,
+    pub late_move_reductions_centi_base: usize,
+    pub late_move_reductions_centi_divisor: usize,
     pub see_pruning_margin_quiet: Score,
     pub see_pruning_margin_tactical: Score,
     pub see_pruning_max_depth: usize,
@@ -69,6 +75,8 @@ impl Default for SearchParams {
             late_move_pruning_base: LATE_MOVE_PRUNING_BASE,
             late_move_pruning_factor: LATE_MOVE_PRUNING_FACTOR,
             late_move_pruning_max_depth: LATE_MOVE_PRUNING_MAX_DEPTH,
+            late_move_reductions_centi_base: LATE_MOVE_REDUCTIONS_CENTI_BASE,
+            late_move_reductions_centi_divisor: LATE_MOVE_REDUCTIONS_CENTI_DIVISOR,
             see_pruning_margin_quiet: SEE_PRUNING_MARGIN_QUIET,
             see_pruning_margin_tactical: SEE_PRUNING_MARGIN_TACTICAL,
             see_pruning_max_depth: SEE_PRUNING_MAX_DEPTH,
@@ -89,6 +97,8 @@ pub struct SearchParamsOptions {
     pub late_move_pruning_base: Option<usize>,
     pub late_move_pruning_factor: Option<usize>,
     pub late_move_pruning_max_depth: Option<usize>,
+    pub late_move_reductions_centi_base: Option<usize>,
+    pub late_move_reductions_centi_divisor: Option<usize>,
     pub see_pruning_margin_quiet: Option<Score>,
     pub see_pruning_margin_tactical: Option<Score>,
     pub see_pruning_max_depth: Option<usize>,

--- a/search/src/searcher.rs
+++ b/search/src/searcher.rs
@@ -1,6 +1,6 @@
 use crate::{
     search::{Search, SearchCommand, SearchInfo},
-    search_params::SearchParamsEachAlgo,
+    search_params::SearchParamsOptions,
     SearchOptions,
 };
 use crossbeam_channel::{bounded, unbounded, Receiver, Sender};
@@ -36,7 +36,7 @@ impl Searcher {
             .expect_err("Expected sender to disconnect after ClearHashTable");
     }
 
-    pub fn set_search_params(&self, search_params: SearchParamsEachAlgo) {
+    pub fn set_search_params(&self, search_params: SearchParamsOptions) {
         let (sender, receiver) = bounded(1);
         self.command_sender
             .send(SearchCommand::SetSearchParams(search_params, sender))
@@ -155,7 +155,7 @@ impl Worker {
         search.clear_hash_table();
     }
 
-    fn set_search_params(search: &mut impl Search, search_params: SearchParamsEachAlgo) {
+    fn set_search_params(search: &mut impl Search, search_params: SearchParamsOptions) {
         search.set_params(search_params);
     }
 

--- a/search/tests/search.rs
+++ b/search/tests/search.rs
@@ -400,7 +400,7 @@ fn underpromotions(search_algo: impl Search + Send + 'static) {
         ),
         (
             "4Q3/Pq4pk/5p1p/5P1K/6PP/8/8/8 w - - 0 1",
-            10,
+            14,
             Move::new(Square::A7, Square::A8, MoveType::PROMOTION_BISHOP),
         ),
     ];
@@ -408,6 +408,7 @@ fn underpromotions(search_algo: impl Search + Send + 'static) {
     for (fen, depth, exp_move) in test_positions_underpromo {
         let pos = Fen::str_to_pos(fen).unwrap();
         let pos_history = PositionHistory::new(pos.clone());
+        tester.clear_hash_table();
         let res = tester.search(pos_history, depth);
         tester.clear_hash_table();
         assert_eq!(
@@ -578,7 +579,7 @@ fn mate_in_x_various_depths(search_algo: impl Search + Send + 'static) {
         // Mate in 2
         (
             "1r6/3N1p1r/2Rp4/1k1P2pp/R7/PP4P1/7P/6K1 w - - 3 41",
-            3,
+            10,
             ScoreVariant::Mate(Side::White, 2),
         ),
         // Mate in 2
@@ -592,6 +593,7 @@ fn mate_in_x_various_depths(search_algo: impl Search + Send + 'static) {
     for (fen, depth, exp_score) in test_positions {
         let pos = Fen::str_to_pos(fen).unwrap();
         let pos_history = PositionHistory::new(pos.clone());
+        tester.clear_hash_table();
         let res = tester.search(pos_history, depth);
         assert_eq!(exp_score, ScoreVariant::from(res.score()));
     }
@@ -603,7 +605,7 @@ fn pv_truncated_after_mate(search_algo: impl Search + Send + 'static) {
         // Mate in 3
         (
             "r2N1b2/p2b1Bp1/n4p2/1p1p3R/3P2k1/P7/1PP2KPP/8 w - - 0 27",
-            11,
+            12,
             ScoreVariant::Mate(Side::White, 3),
             5,
         ),
@@ -612,6 +614,7 @@ fn pv_truncated_after_mate(search_algo: impl Search + Send + 'static) {
     for (fen, depth, exp_score, pv_len) in test_positions {
         let pos = Fen::str_to_pos(fen).unwrap();
         let pos_history = PositionHistory::new(pos.clone());
+        tester.clear_hash_table();
         let res = tester.search(pos_history, depth);
         assert_eq!(exp_score, ScoreVariant::from(res.score()));
         assert_eq!(pv_len, res.principal_variation().len());

--- a/search/tests/search.rs
+++ b/search/tests/search.rs
@@ -573,13 +573,13 @@ fn mate_in_x_various_depths(search_algo: impl Search + Send + 'static) {
         // Mate in 5
         (
             "8/2p5/4k3/8/P2B4/r7/6rP/3K4 b - - 6 51",
-            14,
+            15,
             ScoreVariant::Mate(Side::Black, -5),
         ),
         // Mate in 2
         (
             "1r6/3N1p1r/2Rp4/1k1P2pp/R7/PP4P1/7P/6K1 w - - 3 41",
-            10,
+            11,
             ScoreVariant::Mate(Side::White, 2),
         ),
         // Mate in 2
@@ -605,7 +605,7 @@ fn pv_truncated_after_mate(search_algo: impl Search + Send + 'static) {
         // Mate in 3
         (
             "r2N1b2/p2b1Bp1/n4p2/1p1p3R/3P2k1/P7/1PP2KPP/8 w - - 0 27",
-            12,
+            13,
             ScoreVariant::Mate(Side::White, 3),
             5,
         ),

--- a/uci/src/uci_option.rs
+++ b/uci/src/uci_option.rs
@@ -159,6 +159,24 @@ fn set_late_move_pruning_max_depth(engine: &mut Engine, depth: i64) -> String {
 }
 
 #[allow(dead_code)]
+fn set_late_move_reductions_centi_base(engine: &mut Engine, centi_base: i64) -> String {
+    engine.set_search_params(SearchParamsOptions {
+        late_move_reductions_centi_base: Some(centi_base as usize),
+        ..Default::default()
+    });
+    format!("late-move-reductions-centi-base set to {centi_base}")
+}
+
+#[allow(dead_code)]
+fn set_late_move_reductions_centi_divisor(engine: &mut Engine, centi_divisor: i64) -> String {
+    engine.set_search_params(SearchParamsOptions {
+        late_move_reductions_centi_divisor: Some(centi_divisor as usize),
+        ..Default::default()
+    });
+    format!("late-move-reductions-centi-divisor set to {centi_divisor}")
+}
+
+#[allow(dead_code)]
 fn set_see_pruning_margin_quiet(engine: &mut Engine, margin_quiet: i64) -> String {
     engine.set_search_params(SearchParamsOptions {
         see_pruning_margin_quiet: Some(margin_quiet as Score),

--- a/uci/src/uci_option.rs
+++ b/uci/src/uci_option.rs
@@ -1,7 +1,7 @@
 use engine::{Engine, Variant, DEFAULT_HASH_MB, DEFAULT_MOVE_OVERHEAD_MILLIS};
 use eval::Score;
 use movegen::file::File;
-use search::search_params::{AlphaBetaParams, SearchParamsEachAlgo};
+use search::search_params::SearchParamsOptions;
 use std::time::Duration;
 
 #[allow(dead_code)]
@@ -79,126 +79,126 @@ fn set_chess_960(engine: &mut Engine, enable: bool) -> String {
 
 #[allow(dead_code)]
 fn set_futility_margin_base(engine: &mut Engine, margin_base: i64) -> String {
-    engine.set_search_params(SearchParamsEachAlgo::AlphaBeta(AlphaBetaParams {
+    engine.set_search_params(SearchParamsOptions {
         futility_margin_base: Some(margin_base as Score),
         ..Default::default()
-    }));
+    });
     format!("futility-margin-base set to {margin_base}")
 }
 
 #[allow(dead_code)]
 fn set_futility_margin_per_depth(engine: &mut Engine, margin_per_depth: i64) -> String {
-    engine.set_search_params(SearchParamsEachAlgo::AlphaBeta(AlphaBetaParams {
+    engine.set_search_params(SearchParamsOptions {
         futility_margin_per_depth: Some(margin_per_depth as Score),
         ..Default::default()
-    }));
+    });
     format!("futility-margin-per-depth set to {margin_per_depth}")
 }
 
 #[allow(dead_code)]
 fn set_futility_pruning_max_depth(engine: &mut Engine, depth: i64) -> String {
-    engine.set_search_params(SearchParamsEachAlgo::AlphaBeta(AlphaBetaParams {
+    engine.set_search_params(SearchParamsOptions {
         futility_pruning_max_depth: Some(depth as usize),
         ..Default::default()
-    }));
+    });
     format!("futility-pruning-max-depth set to {depth}")
 }
 
 #[allow(dead_code)]
 fn set_reverse_futility_margin_base(engine: &mut Engine, margin_base: i64) -> String {
-    engine.set_search_params(SearchParamsEachAlgo::AlphaBeta(AlphaBetaParams {
+    engine.set_search_params(SearchParamsOptions {
         reverse_futility_margin_base: Some(margin_base as Score),
         ..Default::default()
-    }));
+    });
     format!("reverse-futility-margin-base set to {margin_base}")
 }
 
 #[allow(dead_code)]
 fn set_reverse_futility_margin_per_depth(engine: &mut Engine, margin_per_depth: i64) -> String {
-    engine.set_search_params(SearchParamsEachAlgo::AlphaBeta(AlphaBetaParams {
+    engine.set_search_params(SearchParamsOptions {
         reverse_futility_margin_per_depth: Some(margin_per_depth as Score),
         ..Default::default()
-    }));
+    });
     format!("reverse-futility-margin-per-depth set to {margin_per_depth}")
 }
 
 #[allow(dead_code)]
 fn set_reverse_futility_pruning_max_depth(engine: &mut Engine, depth: i64) -> String {
-    engine.set_search_params(SearchParamsEachAlgo::AlphaBeta(AlphaBetaParams {
+    engine.set_search_params(SearchParamsOptions {
         reverse_futility_pruning_max_depth: Some(depth as usize),
         ..Default::default()
-    }));
+    });
     format!("reverse-futility-pruning-max-depth set to {depth}")
 }
 
 #[allow(dead_code)]
 fn set_late_move_pruning_base(engine: &mut Engine, base: i64) -> String {
-    engine.set_search_params(SearchParamsEachAlgo::AlphaBeta(AlphaBetaParams {
+    engine.set_search_params(SearchParamsOptions {
         late_move_pruning_base: Some(base as usize),
         ..Default::default()
-    }));
+    });
     format!("late-move-pruning-base set to {base}")
 }
 
 #[allow(dead_code)]
 fn set_late_move_pruning_factor(engine: &mut Engine, factor: i64) -> String {
-    engine.set_search_params(SearchParamsEachAlgo::AlphaBeta(AlphaBetaParams {
+    engine.set_search_params(SearchParamsOptions {
         late_move_pruning_factor: Some(factor as usize),
         ..Default::default()
-    }));
+    });
     format!("late-move-pruning-factor set to {factor}")
 }
 
 #[allow(dead_code)]
 fn set_late_move_pruning_max_depth(engine: &mut Engine, depth: i64) -> String {
-    engine.set_search_params(SearchParamsEachAlgo::AlphaBeta(AlphaBetaParams {
+    engine.set_search_params(SearchParamsOptions {
         late_move_pruning_max_depth: Some(depth as usize),
         ..Default::default()
-    }));
+    });
     format!("late-move-pruning-max-depth set to {depth}")
 }
 
 #[allow(dead_code)]
 fn set_see_pruning_margin_quiet(engine: &mut Engine, margin_quiet: i64) -> String {
-    engine.set_search_params(SearchParamsEachAlgo::AlphaBeta(AlphaBetaParams {
+    engine.set_search_params(SearchParamsOptions {
         see_pruning_margin_quiet: Some(margin_quiet as Score),
         ..Default::default()
-    }));
+    });
     format!("see-pruning-margin-quiet set to {margin_quiet}")
 }
 
 #[allow(dead_code)]
 fn set_see_pruning_margin_tactical(engine: &mut Engine, margin_tactical: i64) -> String {
-    engine.set_search_params(SearchParamsEachAlgo::AlphaBeta(AlphaBetaParams {
+    engine.set_search_params(SearchParamsOptions {
         see_pruning_margin_tactical: Some(margin_tactical as Score),
         ..Default::default()
-    }));
+    });
     format!("see-pruning-margin-tactical set to {margin_tactical}")
 }
 
 #[allow(dead_code)]
 fn set_see_pruning_max_depth(engine: &mut Engine, depth: i64) -> String {
-    engine.set_search_params(SearchParamsEachAlgo::AlphaBeta(AlphaBetaParams {
+    engine.set_search_params(SearchParamsOptions {
         see_pruning_max_depth: Some(depth as usize),
         ..Default::default()
-    }));
+    });
     format!("see-pruning-max-depth set to {depth}")
 }
 
 #[allow(dead_code)]
 fn set_aspiration_window_initial_width(engine: &mut Engine, width: i64) -> String {
-    engine.set_search_params(SearchParamsEachAlgo::AlphaBeta(AlphaBetaParams {
+    engine.set_search_params(SearchParamsOptions {
         aspiration_window_initial_width: Some(width as i32),
         ..Default::default()
-    }));
+    });
     format!("aspiration-window-initial-width set to {width}")
 }
 
 #[allow(dead_code)]
 fn set_aspiration_window_grow_rate(engine: &mut Engine, grow_rate: i64) -> String {
-    engine.set_search_params(SearchParamsEachAlgo::AlphaBeta(AlphaBetaParams {
+    engine.set_search_params(SearchParamsOptions {
         aspiration_window_grow_rate: Some(grow_rate as i32),
         ..Default::default()
-    }));
+    });
     format!("aspiration-window-grow-rate set to {grow_rate}")
 }


### PR DESCRIPTION
- Allow them in PV nodes and in extended searches
- Use move count instead of quiet move count